### PR TITLE
Can override the function to calculate total items

### DIFF
--- a/fastapi_pagination/paginator.py
+++ b/fastapi_pagination/paginator.py
@@ -1,4 +1,4 @@
-from typing import Optional, Sequence, TypeVar
+from typing import Callable, Optional, Sequence, TypeVar
 
 from .api import create_page, resolve_params
 from .bases import AbstractPage, AbstractParams
@@ -9,13 +9,14 @@ T = TypeVar("T")
 def paginate(
     sequence: Sequence[T],
     params: Optional[AbstractParams] = None,
+    length_function: Callable[Sequence[T], int] = len,
 ) -> AbstractPage[T]:
     params = resolve_params(params)
     raw_params = params.to_raw_params()
 
     return create_page(
         items=sequence[raw_params.offset : raw_params.offset + raw_params.limit],
-        total=len(sequence),
+        total=length_function(sequence),
         params=params,
     )
 

--- a/fastapi_pagination/paginator.py
+++ b/fastapi_pagination/paginator.py
@@ -9,7 +9,7 @@ T = TypeVar("T")
 def paginate(
     sequence: Sequence[T],
     params: Optional[AbstractParams] = None,
-    length_function: Callable[Sequence[T], int] = len,
+    length_function: Callable[[Sequence[T]], int] = len,
 ) -> AbstractPage[T]:
     params = resolve_params(params)
     raw_params = params.to_raw_params()


### PR DESCRIPTION
Some ORMs like Django's retrieve all items when using `len()` on a QuerySet. This makes requesting a single page just as slow (if not slower) than requesting the entire set. This allows using the `QuerySet.count()` function which is the recommended method.