### PR TITLE
Fix example in first-steps page

### DIFF
--- a/docs/first-steps.md
+++ b/docs/first-steps.md
@@ -9,7 +9,7 @@ functions from `fastapi_pagination`.
 
 ```python
 from fastapi_pagination import Page, Params, paginate
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI
 from pydantic import BaseModel
 
 
@@ -20,7 +20,7 @@ class User(BaseModel):
 app = FastAPI()
 
 users = [
-    User("Yurii"),
+    User(name="Yurii"),
     # ...
 ]
 
@@ -29,7 +29,7 @@ users = [
     "/",
     response_model=Page[User],
 )
-def route(params: Params):
+def route(params: Params = Depends(Params)):
     return paginate(users, params)
 ```
 
@@ -49,7 +49,7 @@ class User(BaseModel):
 app = FastAPI()
 
 users = [
-    User("Yurii"),
+    User(name="Yurii"),
     # ...
 ]
 

--- a/docs/first-steps.md
+++ b/docs/first-steps.md
@@ -29,7 +29,7 @@ users = [
     "/",
     response_model=Page[User],
 )
-def route(params: Params = Depends(Params)):
+def route(params: Params = Depends()):
     return paginate(users, params)
 ```
 


### PR DESCRIPTION
- Fix incorrect usage of Pydantic. It requires keyword arguments for initialization
- Fix incorrect usages of object query parameters. Pydantic models (of which `Params` is) are always interpreted as POST bodies unless wrapped in Depends

  - Before:

  - <img width="1231" alt="Screen Shot 2021-04-22 at 9 01 03 AM" src="https://user-images.githubusercontent.com/10340167/115718631-4a55a900-a349-11eb-89ea-b20f803eb2f8.png">
   - After:
   - <img width="1229" alt="Screen Shot 2021-04-22 at 9 01 56 AM" src="https://user-images.githubusercontent.com/10340167/115718734-69543b00-a349-11eb-98a0-e6ba427ee26e.png">
