### PR TITLE
Replace gt=0 with ge=1 to avoid problems with exclusiveMinimum

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -93,7 +93,7 @@ T = TypeVar("T")
 
 
 class Params(BaseParams):
-    size: int = Query(500, gt=0, le=1_000, description="Page size")
+    size: int = Query(500, ge=1, le=1_000, description="Page size")
 
 
 class Page(BasePage[T], Generic[T]):

--- a/fastapi_pagination/default.py
+++ b/fastapi_pagination/default.py
@@ -12,8 +12,8 @@ T = TypeVar("T")
 
 
 class Params(BaseModel, AbstractParams):
-    page: int = Query(1, gt=0, description="Page number")
-    size: int = Query(50, gt=0, le=100, description="Page size")
+    page: int = Query(1, ge=1, description="Page number")
+    size: int = Query(50, ge=1, le=100, description="Page size")
 
     def to_raw_params(self) -> RawParams:
         return RawParams(
@@ -29,8 +29,8 @@ class PaginationParams(Params):
 
 
 class Page(BasePage[T], Generic[T]):
-    page: conint(gt=0)  # type: ignore
-    size: conint(gt=0)  # type: ignore
+    page: conint(ge=1)  # type: ignore
+    size: conint(ge=1)  # type: ignore
 
     __params_type__ = Params
 

--- a/fastapi_pagination/limit_offset.py
+++ b/fastapi_pagination/limit_offset.py
@@ -13,7 +13,7 @@ T = TypeVar("T")
 
 
 class LimitOffsetParams(BaseModel, AbstractParams):
-    limit: int = Query(50, gt=0, le=100, description="Page size limit")
+    limit: int = Query(50, ge=1, le=100, description="Page size limit")
     offset: int = Query(0, ge=0, description="Page offset")
 
     def to_raw_params(self) -> RawParams:
@@ -24,7 +24,7 @@ class LimitOffsetParams(BaseModel, AbstractParams):
 
 
 class LimitOffsetPage(BasePage[T], Generic[T]):
-    limit: conint(gt=0)  # type: ignore
+    limit: conint(ge=1)  # type: ignore
     offset: conint(ge=0)  # type: ignore
 
     __params_type__ = LimitOffsetParams


### PR DESCRIPTION
exclusiveMinimum causes problems with openapi spec validation:
https://github.com/tiangolo/fastapi/issues/240
https://github.com/tiangolo/fastapi/issues/3541

Closes #147