### PR TITLE
🔧 Fix parameters description can not show in openapi schema

### DIFF
--- a/fastapi_pagination/default.py
+++ b/fastapi_pagination/default.py
@@ -16,8 +16,8 @@ class Params(BaseModel, AbstractParams):
 
     def to_raw_params(self) -> RawParams:
         return RawParams(
-            limit=self.size,
-            offset=self.size * (self.page - 1),
+            limit=int(self.size),
+            offset=int(self.size) * (int(self.page) - 1),
         )
 
 

--- a/fastapi_pagination/default.py
+++ b/fastapi_pagination/default.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Generic, Sequence, TypeVar
 
 from fastapi import Query
-from pydantic import BaseModel, conint
+from pydantic import BaseModel, conint, Field
 
 from .bases import AbstractParams, BasePage, RawParams
 
@@ -11,8 +11,8 @@ T = TypeVar("T")
 
 
 class Params(BaseModel, AbstractParams):
-    page: int = Query(1, ge=1, description="Page number")
-    size: int = Query(50, ge=1, le=100, description="Page size")
+    page: int = Field(Query(1, ge=1, description="Page number"))
+    size: int = Field(Query(50, ge=1, le=100, description="Page size"))
 
     def to_raw_params(self) -> RawParams:
         return RawParams(


### PR DESCRIPTION
By reading source code I found solution:
```py
class CommonParams(BaseModel):
    a: int = Field(
        Query(...,example=1,description="Description does not show up in docs",
    )
    b: int = Query(
        Query(..., example=2, description="Using query changes nothing")
    ) # this is also ok
```

The code is here: https://github.com/tiangolo/fastapi/blob/master/fastapi/dependencies/utils.py#L361

Which is not so obvious, but really effective.

_Originally posted by @long2ice in https://github.com/tiangolo/fastapi/issues/4700#issuecomment-1149404526_


# This PR
Before repair:
![image](https://user-images.githubusercontent.com/18505474/173188937-f1ddfad8-f291-4a37-8e5c-a7441018b7a1.png)

After repair:
![image](https://user-images.githubusercontent.com/18505474/173188899-83df20c3-1d01-4f96-8b01-3cd8052eeb0a.png)
