### PR TITLE
Fixed issue getting total value when data is empty

### DIFF
--- a/fastapi_pagination/ext/motor.py
+++ b/fastapi_pagination/ext/motor.py
@@ -51,8 +51,12 @@ async def paginate_aggregate(
     )
 
     data = (await cursor.to_list(length=None))[0]
-    total = data["metadata"][0]["total"]
+
     items = data["data"]
+    try:
+        total = data["metadata"][0]["total"]
+    except IndexError:
+        total = 0
 
     return create_page(items, total, params, **(additional_data or {}))
 


### PR DESCRIPTION
When the method `paginate_aggregate` is called with a query that doesn't return records the `total` value raise an exception because the `metadata` key is an empty list, and getting `[0]` raise an `IndexError`.