### PR TITLE
Add custom page

### DIFF
--- a/examples/pagination_async_sqlalchemy.py
+++ b/examples/pagination_async_sqlalchemy.py
@@ -10,7 +10,7 @@ from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.future import select
 from sqlalchemy.orm import sessionmaker
 
-from fastapi_pagination import LimitOffsetPage, Page, add_pagination
+from fastapi_pagination import LimitOffsetPage, CustomPage, Page, add_pagination
 from fastapi_pagination.ext.async_sqlalchemy import paginate
 
 faker = Faker()
@@ -71,6 +71,7 @@ async def create_user(user_in: UserIn, db: AsyncSession = Depends(get_db)) -> Us
 
 @app.get("/users/default", response_model=Page[UserOut])
 @app.get("/users/limit-offset", response_model=LimitOffsetPage[UserOut])
+@app.get("/users/custom-page", response_model=CustomPage[UserOut])
 async def get_users(db: AsyncSession = Depends(get_db)) -> Any:
     return await paginate(db, select(User))
 

--- a/examples/pagination_asyncpg.py
+++ b/examples/pagination_asyncpg.py
@@ -6,7 +6,7 @@ from faker import Faker
 from fastapi import FastAPI
 from pydantic import BaseModel
 
-from fastapi_pagination import LimitOffsetPage, Page, add_pagination
+from fastapi_pagination import LimitOffsetPage, CustomPage, Page, add_pagination
 from fastapi_pagination.ext.asyncpg import paginate
 
 faker = Faker()
@@ -66,6 +66,7 @@ async def create_user(user_in: UserIn) -> Any:
 
 @app.get("/users/default", response_model=Page[UserOut])
 @app.get("/users/limit-offset", response_model=LimitOffsetPage[UserOut])
+@app.get("/users/custom-page", response_model=CustomPage[UserOut])
 async def get_users() -> Any:
     async with pool.acquire() as conn:
         return await paginate(conn, """SELECT id, name, email FROM users WHERE id=$1""")

--- a/examples/pagination_beanie.py
+++ b/examples/pagination_beanie.py
@@ -7,7 +7,7 @@ from fastapi import FastAPI
 from motor.motor_asyncio import AsyncIOMotorClient
 from pydantic import Field
 
-from fastapi_pagination import LimitOffsetPage, Page, add_pagination
+from fastapi_pagination import LimitOffsetPage, CustomPage, Page, add_pagination
 from fastapi_pagination.ext.beanie import paginate
 
 faker = Faker()
@@ -47,6 +47,7 @@ async def create_user(user_in: UserIn) -> Any:
 
 @app.get("/users/default", response_model=Page[UserOut])
 @app.get("/users/limit-offset", response_model=LimitOffsetPage[UserOut])
+@app.get("/users/custom-page", response_model=CustomPage[UserOut])
 async def get_users() -> Any:
     return await paginate(UserIn)
 

--- a/examples/pagination_databases.py
+++ b/examples/pagination_databases.py
@@ -7,7 +7,7 @@ from faker import Faker
 from fastapi import FastAPI
 from pydantic import BaseModel
 
-from fastapi_pagination import LimitOffsetPage, Page, add_pagination
+from fastapi_pagination import LimitOffsetPage, CustomPage, Page, add_pagination
 from fastapi_pagination.ext.databases import paginate
 
 faker = Faker()
@@ -71,6 +71,7 @@ async def create_user(user_in: UserIn) -> Any:
 
 @app.get("/users/default", response_model=Page[UserOut])
 @app.get("/users/limit-offset", response_model=LimitOffsetPage[UserOut])
+@app.get("/users/custom-page", response_model=CustomPage[UserOut])
 async def get_users() -> Any:
     return await paginate(db, Users.select())
 

--- a/examples/pagination_gino.py
+++ b/examples/pagination_gino.py
@@ -7,7 +7,7 @@ from gino_starlette import Gino
 from pydantic import BaseModel
 from sqlalchemy import Column, Integer, String
 
-from fastapi_pagination import LimitOffsetPage, Page, add_pagination
+from fastapi_pagination import LimitOffsetPage, CustomPage, Page, add_pagination
 from fastapi_pagination.ext.gino import paginate
 
 faker = Faker()
@@ -61,6 +61,7 @@ async def create_user(user_in: UserIn) -> Any:
 
 @app.get("/users/default", response_model=Page[UserOut])
 @app.get("/users/limit-offset", response_model=LimitOffsetPage[UserOut])
+@app.get("/users/custom-page", response_model=CustomPage[UserOut])
 async def get_users() -> Any:
     return await paginate(User.query)
 

--- a/examples/pagination_mongoengine.py
+++ b/examples/pagination_mongoengine.py
@@ -8,7 +8,7 @@ from fastapi.encoders import jsonable_encoder
 from mongoengine import Document, connect, fields
 from pydantic import BaseModel, Field
 
-from fastapi_pagination import LimitOffsetPage, Page, add_pagination
+from fastapi_pagination import LimitOffsetPage, CustomPage, Page, add_pagination
 from fastapi_pagination.ext.mongoengine import paginate
 
 faker = Faker()
@@ -64,6 +64,7 @@ async def create_user(user_in: UserIn) -> Any:
 
 @app.get("/users/default", response_model=Page[UserOut])
 @app.get("/users/limit-offset", response_model=LimitOffsetPage[UserOut])
+@app.get("/users/custom-page", response_model=CustomPage[UserOut])
 async def get_users() -> Any:
     return paginate(User)
 

--- a/examples/pagination_motor.py
+++ b/examples/pagination_motor.py
@@ -7,7 +7,7 @@ from fastapi.encoders import jsonable_encoder
 from motor.motor_asyncio import AsyncIOMotorClient
 from pydantic import BaseModel
 
-from fastapi_pagination import LimitOffsetPage, Page, add_pagination
+from fastapi_pagination import LimitOffsetPage, CustomPage, Page, add_pagination
 from fastapi_pagination.ext.motor import paginate
 
 faker = Faker()
@@ -45,6 +45,7 @@ async def create_user(user_in: UserIn) -> Any:
 
 @app.get("/users/default", response_model=Page[UserOut])
 @app.get("/users/limit-offset", response_model=LimitOffsetPage[UserOut])
+@app.get("/users/custom-page", response_model=CustomPage[UserOut])
 async def get_users() -> Any:
     return await paginate(client.test.users)
 

--- a/examples/pagination_orm.py
+++ b/examples/pagination_orm.py
@@ -8,7 +8,7 @@ from fastapi import FastAPI
 from orm import Integer, Model, String
 from pydantic import BaseModel
 
-from fastapi_pagination import LimitOffsetPage, Page, add_pagination
+from fastapi_pagination import LimitOffsetPage, CustomPage, Page, add_pagination
 from fastapi_pagination.ext.orm import paginate
 
 faker = Faker()
@@ -69,6 +69,7 @@ async def create_user(user_in: UserIn) -> Any:
 
 @app.get("/users/default", response_model=Page[UserOut])
 @app.get("/users/limit-offset", response_model=LimitOffsetPage[UserOut])
+@app.get("/users/custom-page", response_model=CustomPage[UserOut])
 async def get_users() -> Any:
     return await paginate(User.objects)
 

--- a/examples/pagination_ormar.py
+++ b/examples/pagination_ormar.py
@@ -7,7 +7,7 @@ from faker import Faker
 from fastapi import FastAPI
 from ormar import Integer, Model, String
 
-from fastapi_pagination import LimitOffsetPage, Page, add_pagination
+from fastapi_pagination import LimitOffsetPage, CustomPage, Page, add_pagination
 from fastapi_pagination.ext.ormar import paginate
 
 faker = Faker()
@@ -57,6 +57,7 @@ async def create_user(user_in: User) -> Any:
 
 @app.get("/users/default", response_model=Page[User])
 @app.get("/users/limit-offset", response_model=LimitOffsetPage[User])
+@app.get("/users/custom-page", response_model=CustomPage[User])
 async def get_users() -> Any:
     return await paginate(User.objects)
 

--- a/examples/pagination_piccolo.py
+++ b/examples/pagination_piccolo.py
@@ -12,7 +12,7 @@ from piccolo.engine import SQLiteEngine, engine_finder
 from piccolo.table import Table
 from pydantic import BaseModel
 
-from fastapi_pagination import LimitOffsetPage, Page, add_pagination
+from fastapi_pagination import LimitOffsetPage, CustomPage, Page, add_pagination
 from fastapi_pagination.ext.piccolo import paginate
 
 os.environ["PICCOLO_CONF"] = __name__
@@ -77,6 +77,7 @@ async def create_user(user_in: UserIn) -> Any:
 
 @app.get("/users/default", response_model=Page[UserOut])
 @app.get("/users/limit-offset", response_model=LimitOffsetPage[UserOut])
+@app.get("/users/custom-page", response_model=CustomPage[UserOut])
 async def get_users() -> Any:
     return await paginate(_User)
 

--- a/examples/pagination_sqlalchemy.py
+++ b/examples/pagination_sqlalchemy.py
@@ -8,7 +8,7 @@ from sqlalchemy import Column, Integer, String, create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import Session, sessionmaker
 
-from fastapi_pagination import LimitOffsetPage, Page, add_pagination
+from fastapi_pagination import LimitOffsetPage, CustomPage, Page, add_pagination
 from fastapi_pagination.ext.sqlalchemy import paginate
 
 faker = Faker()
@@ -75,6 +75,7 @@ def create_user(user_in: UserIn, db: Session = Depends(get_db)) -> User:
 
 @app.get("/users/default", response_model=Page[UserOut])
 @app.get("/users/limit-offset", response_model=LimitOffsetPage[UserOut])
+@app.get("/users/custom-page", response_model=CustomPage[User])
 def get_users(db: Session = Depends(get_db)) -> Any:
     return paginate(db.query(User))
 

--- a/examples/pagination_tortoise.py
+++ b/examples/pagination_tortoise.py
@@ -8,7 +8,7 @@ from tortoise import Model
 from tortoise.contrib.fastapi import register_tortoise
 from tortoise.fields import IntField, TextField
 
-from fastapi_pagination import LimitOffsetPage, Page, add_pagination
+from fastapi_pagination import LimitOffsetPage, CustomPage, Page, add_pagination
 from fastapi_pagination.ext.tortoise import paginate
 
 faker = Faker()
@@ -58,6 +58,7 @@ async def create_user(user_in: UserIn) -> Any:
 
 @app.get("/users/default", response_model=Page[UserOut])
 @app.get("/users/limit-offset", response_model=LimitOffsetPage[UserOut])
+@app.get("/users/custom-page", response_model=CustomPage[User])
 async def get_users() -> Any:
     return await paginate(User)
 

--- a/fastapi_pagination/__init__.py
+++ b/fastapi_pagination/__init__.py
@@ -9,6 +9,7 @@ from .api import (
 )
 from .default import Page, Params
 from .limit_offset import LimitOffsetPage, LimitOffsetParams
+from .custom_page import CustomPage, CustomPageParams
 from .paginator import paginate
 
 __all__ = [
@@ -20,6 +21,8 @@ __all__ = [
     "set_page",
     "Page",
     "Params",
+    "CustomPage",
+    "CustomPageParams",
     "LimitOffsetPage",
     "LimitOffsetParams",
     "paginate",

--- a/fastapi_pagination/custom_page.py
+++ b/fastapi_pagination/custom_page.py
@@ -40,7 +40,7 @@ class CustomPage(BasePage[T], Generic[T]):
         if not isinstance(params, CustomPageParams):
             raise ValueError("Page should be used with Params")
 
-        if params.size is not None and params.size != 0:
+        if params.size is not None and total is not None and params.size != 0:
             pages = ceil(total / params.size)
         else:
             pages = 0

--- a/fastapi_pagination/custom_page.py
+++ b/fastapi_pagination/custom_page.py
@@ -40,7 +40,11 @@ class CustomPage(BasePage[T], Generic[T]):
         if not isinstance(params, CustomPageParams):
             raise ValueError("Page should be used with Params")
 
-        pages = ceil(total / params.size)
+        if params.size is not None and params.size != 0:
+            pages = ceil(total / params.size)
+        else:
+            pages = 0
+
         return cls(
             total=total,
             items=items,
@@ -48,7 +52,7 @@ class CustomPage(BasePage[T], Generic[T]):
             size=params.size,
             pages=pages,
             next_page=params.page + 1 if params.page < pages else None,
-            previous_page=params.page - 1 if params.page > 1 else None,            
+            previous_page=params.page - 1 if params.page > 1 else None,
             **kwargs,
         )
 

--- a/fastapi_pagination/custom_page.py
+++ b/fastapi_pagination/custom_page.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from typing import Any, Generic, Optional, Sequence, TypeVar
+from math import ceil
+from fastapi import Query
+from pydantic import BaseModel
+
+from .bases import AbstractParams, BasePage, RawParams
+from .types import GreaterEqualOne
+
+T = TypeVar("T")
+
+
+class CustomPageParams(BaseModel, AbstractParams):
+    page: int = Query(1, ge=1, description="Page number")
+    size: int = Query(50, ge=1, le=100, description="Page size")
+
+    def to_raw_params(self) -> RawParams:
+        return RawParams(
+            limit=self.size,
+            offset=self.size * (self.page - 1),
+        )
+
+
+class CustomPage(BasePage[T], Generic[T]):
+    page: GreaterEqualOne
+    size: GreaterEqualOne
+
+    __params_type__ = CustomPageParams
+
+    @classmethod
+    def create(
+        cls,
+        items: Sequence[T],
+        params: AbstractParams,
+        *,
+        total: Optional[int] = None,
+        **kwargs: Any,
+    ) -> CustomPage[T]:
+        if not isinstance(params, CustomPageParams):
+            raise ValueError("Page should be used with Params")
+
+        pages = ceil(total / params.size)
+        return cls(
+            total=total,
+            items=items,
+            page=params.page,
+            size=params.size,
+            pages=pages,
+            next_page=params.page + 1 if params.page < pages else None,
+            previous_page=params.page - 1 if params.page > 1 else None,            
+            **kwargs,
+        )
+
+
+__all__ = [
+    "CustomPageParams",
+    "CustomPage",
+]


### PR DESCRIPTION
Add custom page to examples. I believe this is an excellent feature that is missing in examples. It is very common that clients require how many pages there are and if there is a next or previous page based on the page they are. I think it is better if this task is handled by backed instead of clients.

Reference: https://uriyyo-fastapi-pagination.netlify.app/customization/