### PR TITLE
Dudzicz/fix pep 8

### DIFF
--- a/fastapi_pagination/__init__.py
+++ b/fastapi_pagination/__init__.py
@@ -1,16 +1,3 @@
-from .api import (
-    add_pagination,
-    create_page,
-    pagination_ctx,
-    request,
-    resolve_params,
-    response,
-    set_page,
-)
-from .default import Page, Params
-from .limit_offset import LimitOffsetPage, LimitOffsetParams
-from .paginator import paginate
-
 __all__ = [
     "add_pagination",
     "create_page",
@@ -25,3 +12,16 @@ __all__ = [
     "paginate",
     "pagination_ctx",
 ]
+
+from .api import (
+    add_pagination,
+    create_page,
+    pagination_ctx,
+    request,
+    resolve_params,
+    response,
+    set_page,
+)
+from .default import Page, Params
+from .limit_offset import LimitOffsetPage, LimitOffsetParams
+from .paginator import paginate

--- a/fastapi_pagination/api.py
+++ b/fastapi_pagination/api.py
@@ -1,3 +1,14 @@
+__all__ = [
+    "add_pagination",
+    "create_page",
+    "resolve_params",
+    "response",
+    "request",
+    "set_page",
+    "pagination_ctx",
+    "pagination_items",
+]
+
 import inspect
 from contextlib import ExitStack, contextmanager, suppress
 from contextvars import ContextVar
@@ -175,15 +186,3 @@ def add_pagination(parent: ParentT) -> ParentT:
         _add_pagination(parent)
 
     return parent
-
-
-__all__ = [
-    "add_pagination",
-    "create_page",
-    "resolve_params",
-    "response",
-    "request",
-    "set_page",
-    "pagination_ctx",
-    "pagination_items",
-]

--- a/fastapi_pagination/bases.py
+++ b/fastapi_pagination/bases.py
@@ -1,5 +1,16 @@
 from __future__ import annotations
 
+__all__ = [
+    "AbstractPage",
+    "AbstractParams",
+    "BasePage",
+    "BaseRawParams",
+    "RawParams",
+    "CursorRawParams",
+    "is_cursor",
+    "is_limit_offset",
+]
+
 import inspect
 import warnings
 from abc import ABC, abstractmethod
@@ -127,7 +138,8 @@ class AbstractPage(GenericModel, Generic[T], ABC):
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         try:
-            is_same = cls.create.__func__ is AbstractPage.create.__func__  # type: ignore[attr-defined]
+            # type: ignore[attr-defined]
+            is_same = cls.create.__func__ is AbstractPage.create.__func__
         except AttributeError:
             is_same = False
 
@@ -163,7 +175,8 @@ class AbstractPage(GenericModel, Generic[T], ABC):
             bases = (cls,)
         else:
             params = tuple(cls.__parameters__)
-            bases = (cls[params], Generic[params])  # type: ignore[assignment, index]
+            # type: ignore[assignment, index]
+            bases = (cls[params], Generic[params])
 
         new_cls = new_class("CustomPage", bases, exec_body=lambda ns: setitem(ns, "__params_type__", custom_params))
         new_cls = update_wrapper(new_cls, cls, updated=())
@@ -177,15 +190,3 @@ class AbstractPage(GenericModel, Generic[T], ABC):
 class BasePage(AbstractPage[T], Generic[T], ABC):
     items: Sequence[T]
     total: GreaterEqualZero
-
-
-__all__ = [
-    "AbstractPage",
-    "AbstractParams",
-    "BasePage",
-    "BaseRawParams",
-    "RawParams",
-    "CursorRawParams",
-    "is_cursor",
-    "is_limit_offset",
-]

--- a/fastapi_pagination/bases.py
+++ b/fastapi_pagination/bases.py
@@ -138,8 +138,7 @@ class AbstractPage(GenericModel, Generic[T], ABC):
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         try:
-            # type: ignore[attr-defined]
-            is_same = cls.create.__func__ is AbstractPage.create.__func__
+            is_same = cls.create.__func__ is AbstractPage.create.__func__  # type: ignore[attr-defined]
         except AttributeError:
             is_same = False
 
@@ -175,8 +174,7 @@ class AbstractPage(GenericModel, Generic[T], ABC):
             bases = (cls,)
         else:
             params = tuple(cls.__parameters__)
-            # type: ignore[assignment, index]
-            bases = (cls[params], Generic[params])
+            bases = (cls[params], Generic[params])  # type: ignore[assignment, index]
 
         new_cls = new_class("CustomPage", bases, exec_body=lambda ns: setitem(ns, "__params_type__", custom_params))
         new_cls = update_wrapper(new_cls, cls, updated=())

--- a/fastapi_pagination/cursor.py
+++ b/fastapi_pagination/cursor.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+__all__ = [
+    "CursorPage",
+    "CursorParams",
+]
+
 from base64 import b64decode, b64encode
 from typing import (
     Any,
@@ -90,9 +95,3 @@ class CursorPage(AbstractPage[T], Generic[T]):
             previous_page=encode_cursor(previous),
             **kwargs,
         )
-
-
-__all__ = [
-    "CursorPage",
-    "CursorParams",
-]

--- a/fastapi_pagination/default.py
+++ b/fastapi_pagination/default.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+__all__ = [
+    "Params",
+    "Page",
+]
+
 from typing import Any, Generic, Optional, Sequence, TypeVar
 
 from fastapi import Query
@@ -47,9 +52,3 @@ class Page(BasePage[T], Generic[T]):
             size=params.size,
             **kwargs,
         )
-
-
-__all__ = [
-    "Params",
-    "Page",
-]

--- a/fastapi_pagination/ext/async_sqlalchemy.py
+++ b/fastapi_pagination/ext/async_sqlalchemy.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+__all__ = ["paginate"]
+
 from typing import Any, Optional
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -21,8 +23,3 @@ async def paginate(
 ) -> AbstractPage[Any]:
     params, _ = verify_params(params, "limit-offset", "cursor")
     return await async_exec_pagination(query, params, conn.execute, additional_data, unique)
-
-
-__all__ = [
-    "paginate",
-]

--- a/fastapi_pagination/ext/async_sqlmodel.py
+++ b/fastapi_pagination/ext/async_sqlmodel.py
@@ -1,3 +1,5 @@
+__all__ = ["paginate"]
+
 from typing import Any, Optional, Type, TypeVar, no_type_check, overload
 
 from sqlmodel import SQLModel, select
@@ -63,8 +65,3 @@ async def paginate(
         query = select(query)
 
     return await async_exec_pagination(query, params, session.exec, additional_data, unique)
-
-
-__all__ = [
-    "paginate",
-]

--- a/fastapi_pagination/ext/asyncpg.py
+++ b/fastapi_pagination/ext/asyncpg.py
@@ -1,3 +1,5 @@
+__all__ = ["paginate"]
+
 from typing import Any, Optional
 
 from asyncpg import Connection
@@ -34,8 +36,3 @@ async def paginate(
         params,
         **(additional_data or {}),
     )
-
-
-__all__ = [
-    "paginate",
-]

--- a/fastapi_pagination/ext/beanie.py
+++ b/fastapi_pagination/ext/beanie.py
@@ -1,3 +1,5 @@
+__all__ = ["paginate"]
+
 from typing import Optional, TypeVar, Union
 
 from beanie import Document
@@ -24,8 +26,3 @@ async def paginate(
     total = await query.find({}, fetch_links=fetch_links).count()
 
     return create_page(items, total, params, **(additional_data or {}))
-
-
-__all__ = [
-    "paginate",
-]

--- a/fastapi_pagination/ext/cassandra.py
+++ b/fastapi_pagination/ext/cassandra.py
@@ -1,3 +1,5 @@
+__all__ = ["paginate"]
+
 from typing import Any, Dict, Mapping, Optional, Type, TypeVar
 
 from cassandra.cluster import SimpleStatement
@@ -34,8 +36,3 @@ def paginate(
     items = cursor.current_rows
 
     return create_page(items, params=params, next_=cursor.paging_state, **(additional_data or {}))
-
-
-__all__ = [
-    "paginate",
-]

--- a/fastapi_pagination/ext/databases.py
+++ b/fastapi_pagination/ext/databases.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+__all__ = ["paginate"]
+
 from typing import Any, List, Optional
 
 from databases import Database
@@ -32,8 +34,3 @@ async def paginate(
         items = [{**item._mapping} for item in raw_items]
 
     return create_page(items, total, params, **(additional_data or {}))
-
-
-__all__ = [
-    "paginate",
-]

--- a/fastapi_pagination/ext/django.py
+++ b/fastapi_pagination/ext/django.py
@@ -1,5 +1,7 @@
 from typing import Optional, Type, TypeVar, Union, cast
 
+__all__ = ["paginate"]
+
 from django.db.models import Model, QuerySet
 from django.db.models.base import ModelBase
 
@@ -26,8 +28,3 @@ def paginate(
     query = query.all()[raw_params.offset : raw_params.offset + raw_params.limit]
 
     return create_page([*query], total, params, **(additional_data or {}))
-
-
-__all__ = [
-    "paginate",
-]

--- a/fastapi_pagination/ext/gino.py
+++ b/fastapi_pagination/ext/gino.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+__all__ = ["paginate"]
+
 from typing import Any, Optional, Union, no_type_check
 
 from gino.crud import CRUDModel
@@ -30,8 +32,3 @@ async def paginate(
     items = await query.gino.all()
 
     return create_page(items, total, params, **(additional_data or {}))
-
-
-__all__ = [
-    "paginate",
-]

--- a/fastapi_pagination/ext/mongoengine.py
+++ b/fastapi_pagination/ext/mongoengine.py
@@ -1,3 +1,5 @@
+__all__ = ["paginate"]
+
 from typing import Optional, Type, TypeVar, Union, cast
 
 from mongoengine import QuerySet
@@ -27,8 +29,3 @@ def paginate(
     items = [item.to_mongo() for item in cursor]
 
     return create_page(items, total, params, **(additional_data or {}))
-
-
-__all__ = [
-    "paginate",
-]

--- a/fastapi_pagination/ext/motor.py
+++ b/fastapi_pagination/ext/motor.py
@@ -1,3 +1,5 @@
+__all__ = ["paginate"]
+
 from typing import Any, Dict, List, Optional
 
 from motor.motor_asyncio import AsyncIOMotorCollection
@@ -59,9 +61,3 @@ async def paginate_aggregate(
         total = 0
 
     return create_page(items, total, params, **(additional_data or {}))
-
-
-__all__ = [
-    "paginate",
-    "paginate_aggregate",
-]

--- a/fastapi_pagination/ext/orm.py
+++ b/fastapi_pagination/ext/orm.py
@@ -1,3 +1,5 @@
+__all__ = ["paginate"]
+
 from typing import Any, Optional
 
 from orm.models import QuerySet
@@ -20,8 +22,3 @@ async def paginate(
     items = await query.limit(raw_params.limit).offset(raw_params.offset).all()
 
     return create_page(items, total, params, **(additional_data or {}))
-
-
-__all__ = [
-    "paginate",
-]

--- a/fastapi_pagination/ext/ormar.py
+++ b/fastapi_pagination/ext/ormar.py
@@ -1,3 +1,5 @@
+__all__ = ["paginate"]
+
 from typing import Optional, Type, TypeVar, Union
 
 from ormar import Model, QuerySet
@@ -25,8 +27,3 @@ async def paginate(
     items = await query.offset(raw_params.offset).limit(raw_params.limit).all()
 
     return create_page(items, total, params, **(additional_data or {}))
-
-
-__all__ = [
-    "paginate",
-]

--- a/fastapi_pagination/ext/piccolo.py
+++ b/fastapi_pagination/ext/piccolo.py
@@ -1,3 +1,5 @@
+__all__ = ["paginate"]
+
 from copy import deepcopy
 from typing import Optional, Type, Union, TypeVar, cast, List
 
@@ -39,8 +41,3 @@ async def paginate(
     items = await query.offset(raw_params.offset).limit(raw_params.limit)
 
     return create_page(cast(List[T], items), total, params, **(additional_data or {}))
-
-
-__all__ = [
-    "paginate",
-]

--- a/fastapi_pagination/ext/pony.py
+++ b/fastapi_pagination/ext/pony.py
@@ -1,3 +1,5 @@
+__all__ = ["paginate"]
+
 from typing import Optional, Any
 
 from pony.orm.core import Query
@@ -21,6 +23,3 @@ def paginate(
     items = query.fetch(raw_params.limit, raw_params.offset).to_list()
 
     return create_page(items, total, params, **(additional_data or {}))
-
-
-__all__ = ["paginate"]

--- a/fastapi_pagination/ext/pymongo.py
+++ b/fastapi_pagination/ext/pymongo.py
@@ -1,3 +1,5 @@
+__all__ = ["paginate"]
+
 from typing import Any, Dict, Mapping, Optional, TypeVar
 
 from pymongo.collection import Collection
@@ -26,8 +28,3 @@ def paginate(
     cursor = collection.find(query_filter, skip=raw_params.offset, limit=raw_params.limit, **kwargs)
 
     return create_page([*cursor], total, params, **(additional_data or {}))
-
-
-__all__ = [
-    "paginate",
-]

--- a/fastapi_pagination/ext/sqlalchemy.py
+++ b/fastapi_pagination/ext/sqlalchemy.py
@@ -77,8 +77,7 @@ def paginate_using_cursor(
             q = q.where(condition)
 
     pagination_info = order_cols, mapped_ocols, extra_columns, keys, backwards, place
-    # 1 extra to check if there's a further page
-    return q.limit(raw_params.size + 1), pagination_info
+    return q.limit(raw_params.size + 1), pagination_info  # 1 extra to check if there's a further page
 
 
 def paginate_cursor_process_items(

--- a/fastapi_pagination/ext/sqlalchemy.py
+++ b/fastapi_pagination/ext/sqlalchemy.py
@@ -1,5 +1,13 @@
 from __future__ import annotations
 
+__all__ = [
+    "paginate_query",
+    "count_query",
+    "paginate",
+    "paginate_using_cursor",
+    "paginate_cursor_process_items",
+]
+
 from typing import Any, Optional, Sequence, Tuple, TypeVar, cast, no_type_check
 
 from fastapi import HTTPException
@@ -69,7 +77,8 @@ def paginate_using_cursor(
             q = q.where(condition)
 
     pagination_info = order_cols, mapped_ocols, extra_columns, keys, backwards, place
-    return q.limit(raw_params.size + 1), pagination_info  # 1 extra to check if there's a further page
+    # 1 extra to check if there's a further page
+    return q.limit(raw_params.size + 1), pagination_info
 
 
 def paginate_cursor_process_items(
@@ -121,12 +130,3 @@ def paginate(
     items = paginate_query(query, params).all()
 
     return create_page(items, total, params, **(additional_data or {}))
-
-
-__all__ = [
-    "paginate_query",
-    "count_query",
-    "paginate",
-    "paginate_using_cursor",
-    "paginate_cursor_process_items",
-]

--- a/fastapi_pagination/ext/sqlalchemy_future.py
+++ b/fastapi_pagination/ext/sqlalchemy_future.py
@@ -1,5 +1,11 @@
 from __future__ import annotations
 
+__all__ = [
+    "paginate",
+    "exec_pagination",
+    "async_exec_pagination",
+]
+
 from typing import Any, Awaitable, Callable, Optional, Union
 
 from sqlalchemy.future import Connection, Engine
@@ -92,10 +98,3 @@ def paginate(
 ) -> AbstractPage[Any]:
     params, _ = verify_params(params, "limit-offset", "cursor")
     return exec_pagination(query, params, conn.execute, additional_data, unique)
-
-
-__all__ = [
-    "paginate",
-    "exec_pagination",
-    "async_exec_pagination",
-]

--- a/fastapi_pagination/ext/sqlmodel.py
+++ b/fastapi_pagination/ext/sqlmodel.py
@@ -1,3 +1,5 @@
+__all__ = ["paginate"]
+
 from typing import Any, Optional, Type, TypeVar, no_type_check, overload
 
 from sqlmodel import Session, SQLModel, select
@@ -63,8 +65,3 @@ def paginate(
         query = select(query)
 
     return exec_pagination(query, params, session.exec, additional_data, unique)
-
-
-__all__ = [
-    "paginate",
-]

--- a/fastapi_pagination/ext/tortoise.py
+++ b/fastapi_pagination/ext/tortoise.py
@@ -1,3 +1,5 @@
+__all__ = ["paginate"]
+
 from typing import List, Optional, Type, TypeVar, Union
 
 from tortoise.models import Model
@@ -41,8 +43,3 @@ async def paginate(
     items = await _generate_query(query, prefetch_related).offset(raw_params.offset).limit(raw_params.limit).all()
 
     return create_page(items, total, params, **(additional_data or {}))
-
-
-__all__ = [
-    "paginate",
-]

--- a/fastapi_pagination/ext/utils.py
+++ b/fastapi_pagination/ext/utils.py
@@ -1,3 +1,8 @@
+__all__ = [
+    "unwrap_scalars",
+    "wrap_scalars",
+]
+
 from typing import Any, Optional, Sequence, TypeVar, Union, no_type_check
 
 T = TypeVar("T")
@@ -18,9 +23,3 @@ def unwrap_scalars(items: Sequence[Sequence[T]]) -> Union[Sequence[T], Sequence[
 @no_type_check
 def wrap_scalars(items: Sequence[Any]) -> Sequence[Sequence[Any]]:
     return [item if len_or_none(item) is not None else [item] for item in items]
-
-
-__all__ = [
-    "unwrap_scalars",
-    "wrap_scalars",
-]

--- a/fastapi_pagination/iterables.py
+++ b/fastapi_pagination/iterables.py
@@ -1,6 +1,14 @@
 from itertools import islice
 from typing import Generic, Iterable, Optional, TypeVar
 
+__all__ = [
+    "Page",
+    "Params",
+    "LimitOffsetPage",
+    "LimitOffsetParams",
+    "paginate",
+]
+
 from .api import create_page
 from .bases import AbstractPage, AbstractParams
 from .default import Page as DefaultPage
@@ -32,12 +40,3 @@ def paginate(
 
     items = [*islice(iterable, raw_params.offset, raw_params.offset + raw_params.limit)]
     return create_page(items, total, params, **(additional_data or {}))
-
-
-__all__ = [
-    "Page",
-    "Params",
-    "LimitOffsetPage",
-    "LimitOffsetParams",
-    "paginate",
-]

--- a/fastapi_pagination/limit_offset.py
+++ b/fastapi_pagination/limit_offset.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+__all__ = [
+    "LimitOffsetPage",
+    "LimitOffsetParams",
+]
+
 from typing import Any, Generic, Optional, Sequence, TypeVar
 
 from fastapi import Query
@@ -46,9 +51,3 @@ class LimitOffsetPage(BasePage[T], Generic[T]):
             offset=raw_params.offset,
             **kwargs,
         )
-
-
-__all__ = [
-    "LimitOffsetPage",
-    "LimitOffsetParams",
-]

--- a/fastapi_pagination/links/bases.py
+++ b/fastapi_pagination/links/bases.py
@@ -1,3 +1,5 @@
+__all__ = ["Links", "create_links"]
+
 from typing import Any, Mapping, Optional
 
 from pydantic import BaseModel, Field
@@ -46,6 +48,3 @@ def create_links(
         next=_update_path(url, next),
         prev=_update_path(url, prev),
     )
-
-
-__all__ = ["Links", "create_links"]

--- a/fastapi_pagination/links/default.py
+++ b/fastapi_pagination/links/default.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+__all__ = ["Page"]
+
 from math import ceil
 from typing import Any, Generic, TypeVar
 
@@ -27,6 +29,3 @@ class Page(BasePage[T], Generic[T]):
             )
 
         return value
-
-
-__all__ = ["Page"]

--- a/fastapi_pagination/links/limmit_offset.py
+++ b/fastapi_pagination/links/limmit_offset.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+__all__ = ["LimitOffsetPage", "Page"]
+
 from math import floor
 from typing import Any, Generic, TypeVar
 
@@ -37,5 +39,3 @@ class LimitOffsetPage(BasePage[T], Generic[T]):
 
 
 Page = LimitOffsetPage
-
-__all__ = ["LimitOffsetPage", "Page"]

--- a/fastapi_pagination/paginator.py
+++ b/fastapi_pagination/paginator.py
@@ -1,5 +1,7 @@
 from typing import Callable, Optional, Sequence, TypeVar
 
+__all__ = ["paginate"]
+
 from .api import create_page
 from .bases import AbstractPage, AbstractParams
 from .types import AdditionalData
@@ -23,6 +25,3 @@ def paginate(
         params,
         **(additional_data or {}),
     )
-
-
-__all__ = ["paginate"]

--- a/fastapi_pagination/types.py
+++ b/fastapi_pagination/types.py
@@ -1,5 +1,13 @@
 from typing import Any, Dict, Optional, Union
 
+__all__ = [
+    "Cursor",
+    "ParamsType",
+    "AdditionalData",
+    "GreaterEqualZero",
+    "GreaterEqualOne",
+]
+
 from pydantic import conint
 from typing_extensions import TYPE_CHECKING, Literal, TypeAlias
 
@@ -13,11 +21,3 @@ if TYPE_CHECKING:
 else:
     GreaterEqualZero: TypeAlias = conint(ge=0)
     GreaterEqualOne: TypeAlias = conint(ge=1)
-
-__all__ = [
-    "Cursor",
-    "ParamsType",
-    "AdditionalData",
-    "GreaterEqualZero",
-    "GreaterEqualOne",
-]

--- a/fastapi_pagination/utils.py
+++ b/fastapi_pagination/utils.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+__all__ = ["verify_params"]
+
 from typing import Optional, Tuple, TypeVar, overload
 
 from typing_extensions import Literal
@@ -34,8 +36,3 @@ def verify_params(params: Optional[TParams], *params_types: ParamsType) -> Tuple
         raise ValueError(f"{raw_params.type!r} params not supported")
 
     return params, raw_params
-
-
-__all__ = [
-    "verify_params",
-]


### PR DESCRIPTION
Changed the location of the `__all__` dunders in order to be compliant with the PEP8 specification, c.f., [PEP8](https://peps.python.org/pep-0008/#module-level-dunder-names).