### PR TITLE
Strip extra lines before and after the _WARNING_MSG

### DIFF
--- a/fastapi_pagination/utils.py
+++ b/fastapi_pagination/utils.py
@@ -108,7 +108,7 @@ Otherwise, you can disable this warning by adding the following code to your cod
 from fastapi_pagination.utils import disable_installed_extensions_check
 
 disable_installed_extensions_check()
-"""
+""".strip()
 
 _CHECK_INSTALLED_EXTENSIONS = True
 


### PR DESCRIPTION
My proposal for `fastapi_pagination/utils.py:_WARNING_MSG` is to remove the extra lines from it. This makes it easier to filter warnings in pytest and other tools.

I've made a proof of concept for this PR https://github.com/frost-nzcr4/fastapi-pagination/tree/poc-pytest-filterwarning-not-matching-the-warning/docker.

You'll need to run:

```shell
git clone https://github.com/frost-nzcr4/fastapi-pagination.git
git checkout poc-pytest-filterwarning-not-matching-the-warning
cd docker
docker build . --tag fastapi-pagination-trim-extra-lines
docker run --rm fastapi-pagination-trim-extra-lines
```
and now you get ready for an error:

```shell
            if _check_installed(f"fastapi_pagination.ext.{ext}"):
>               warnings.warn(
                    _WARNING_MSG.format(ext=ext),
                    FastAPIPaginationWarning,
                    stacklevel=3,
                )
E               fastapi_pagination.utils.FastAPIPaginationWarning: 
E               Package "sqlalchemy" is installed.
E               
E               It's recommended to use extension "fastapi_pagination.ext.sqlalchemy" instead of default 'paginate' implementation.
E               
E               Otherwise, you can disable this warning by adding the following code to your code:
E               from fastapi_pagination.utils import disable_installed_extensions_check
E               
E               disable_installed_extensions_check()

/root/.cache/pypoetry/virtualenvs/fastapi-pagination-trim-extra-lines-_geWzZZ1-py3.11/lib/python3.11/site-packages/fastapi_pagination/utils.py:127: FastAPIPaginationWarning
=========================== short test summary info ============================
FAILED test_utils.py::test_warning - fastapi_pagination.utils.FastAPIPaginati...
```

The leading `\n` in `_WARNING_MSG` is non-obvious to filter with pytest filterwarnings and with `-W`.