### PR TITLE
Move FastAPI to dev dependencies

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2989,4 +2989,4 @@ tortoise = ["tortoise-orm"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4.0"
-content-hash = "4920b534031afaa4fa42fc9af240b557df2ada7456bc3bfa2dbedf0fd0461f49"
+content-hash = "9cf7ef2317e57059bdf5677325563906472ad86bd4028e874f246a3372a65172"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ classifiers = [
 [tool.poetry.dependencies]
 python = ">=3.8,<4.0"
 pydantic = ">=1.9.1"
-fastapi = ">=0.93.0"
 typing-extensions = "^4.8.0"
 SQLAlchemy = { version = ">=1.3.20", optional = true }
 databases = { version = ">=0.6.0", optional = true }
@@ -45,6 +44,7 @@ scylla-driver = {version = "^3.25.6", optional = true}
 bunnet = {version = "^1.1.0", optional = true}
 
 [tool.poetry.dev-dependencies]
+fastapi = ">=0.93.0"
 pytest = "^8.2.1"
 pytest-cov = "^5.0.0"
 pytest-asyncio = "^0.21.1"


### PR DESCRIPTION
Hi! Thanks for this project!

Starting from v0.111 fastapi installs many additional dependencies. Those who don't need them should use fastapi-slim instead. The explicit dependency on fastapi in fastapi-pagination causes all these additional packages to be installed in projects that depend on fastapi-pagination, even if they use fastapi-slim.

This PR moves fastapi to dev dependencies allowing users of fastapi-pagination to independently choose between fastapi and fastapi-slim.