### PR TITLE
added aggregation filter end to mongodb extensions

### DIFF
--- a/fastapi_pagination/ext/motor.py
+++ b/fastapi_pagination/ext/motor.py
@@ -58,6 +58,7 @@ async def apaginate_aggregate(
     *,
     transformer: Optional[AsyncItemsTransformer] = None,
     additional_data: Optional[AdditionalData] = None,
+    aggregation_filter_end: Optional[int] = None,
 ) -> Any:
     params, raw_params = verify_params(params, "limit-offset")
     aggregate_pipeline = aggregate_pipeline or []
@@ -67,6 +68,11 @@ async def apaginate_aggregate(
         paginate_data.append({"$limit": raw_params.limit + (raw_params.offset or 0)})
     if raw_params.offset is not None:
         paginate_data.append({"$skip": raw_params.offset})
+
+    if aggregation_filter_end is not None:
+        transform_part = aggregate_pipeline[aggregation_filter_end:]
+        aggregate_pipeline = aggregate_pipeline[:aggregation_filter_end]
+        paginate_data.extend(transform_part)
 
     cursor = collection.aggregate(
         [


### PR DESCRIPTION
#1537 
Specifies the index in the pipeline at which no documents are being filtered out anymore. Allows for way faster query execution times if heavy transformations happen later in the pipeline such as lookups 