### PR TITLE
Import from non-deprecated location

### DIFF
--- a/fastapi_pagination/utils.py
+++ b/fastapi_pagination/utils.py
@@ -15,7 +15,6 @@ __all__ = [
     "verify_params",
 ]
 
-import asyncio
 import functools
 import inspect
 import warnings
@@ -67,7 +66,7 @@ def is_async_callable(obj: Any) -> bool:  # pragma: no cover
     while isinstance(obj, functools.partial):
         obj = obj.func
 
-    return asyncio.iscoroutinefunction(obj) or (callable(obj) and asyncio.iscoroutinefunction(obj.__call__))
+    return inspect.iscoroutinefunction(obj) or (callable(obj) and inspect.iscoroutinefunction(obj.__call__))
 
 
 P = ParamSpec("P")


### PR DESCRIPTION
This fixes the following warning when using fastapi_pagination with Python 3.14:

```
DeprecationWarning: 'asyncio.iscoroutinefunction' is deprecated and slated for removal in Python 3.16; use inspect.iscoroutinefunction() instead
```

This should be safe for all supported Python versions (>= 3.9), the function is available from the inspect module since Python 3.5.