### PR TITLE
Fix installation command in contributing.md

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -33,7 +33,7 @@ uv sync --dev --all-extras
 
 To install only basic dependencies, run:
 ```sh
-uv install --dev
+uv sync --dev
 ```
 
 To install docs requirements, run:


### PR DESCRIPTION
This pull request updates the documentation to reflect the correct command for installing basic development dependencies. The change ensures contributors use the recommended `uv sync --dev` command instead of the deprecated `uv install --dev`.

Documentation update:

* Updated the installation instructions in `docs/contributing.md` to use `uv sync --dev` for installing basic dependencies.