### PR TITLE
Fix instructions to sync docs requirements in CONTRIBUTING.md

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -38,7 +38,7 @@ uv sync --dev
 
 To install docs requirements, run:
 ```sh
-uv pip install -r docs_requirements.txt
+uv sync --group docs
 ```
 
 ### Step 4: do your changes


### PR DESCRIPTION
This docs_requirements.txt file doesn't seem to exist. I imagine the right way to sync the docs requirements would be by running `uv sync --group docs`