### PR TITLE
Add test for sync paginator length_function

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,20 +20,20 @@ With `fastapi-pagination`, you can easily define pagination parameters in your F
 and use them to generate paginated responses that include the requested subset of your data.
 The library supports a variety of pagination strategies, including cursor-based pagination and page-based pagination.
 
-`fastapi-pagination` is built on top of the popular `fastapi` library, and it works with a wide range 
-of SQL and NoSQL databases frameworks. It also supports async/await syntax and is compatible with Python 3.10 and higher.
+`fastapi-pagination` is built on top of the popular `fastapi` library, and it works with a wide range
+of SQL and NoSQL database frameworks. It also supports async/await syntax and is compatible with Python 3.10 and higher.
 
 Features:
 
 * Simplifies pagination in FastAPI applications.
 * Supports a variety of pagination strategies, including cursor-based pagination and page-based pagination
-* Works with a wide range of SQL and NoSQL databases frameworks, including `SQLAlchemy`, `Tortoise ORM`, and `PyMongo`.
+* Works with a wide range of SQL and NoSQL database frameworks, including `SQLAlchemy`, `Tortoise ORM`, and `PyMongo`.
 * Supports async/await syntax.
 * Compatible with Python 3.10 and higher.
 
 ----
 
-For more information on how to use fastapi-pagination, please refer to the 
+For more information on how to use fastapi-pagination, please refer to the
 [official documentation](https://uriyyo-fastapi-pagination.netlify.app/).
 
 ---
@@ -94,7 +94,7 @@ def get_users(db: Session = Depends(get_db)) -> Page[UserOut]:
 
 ---
 
-Code from `Quickstart` will generate OpenAPI schema as bellow:
+Code from `Quickstart` will generate OpenAPI schema as below:
 
 <div align="center">
 <img alt="app-example" src="https://raw.githubusercontent.com/uriyyo/fastapi-pagination/main/docs/img/example.png">

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -115,7 +115,7 @@ If you want to run only unit tests, run:
 uv run pytest tests --unit-tests
 ```
 
-If you want to run only integration tests, then you will also will need to have `PostgreSQL`, `MongoDB` and `Casandra` running.
+If you want to run only integration tests, then you will also need to have `PostgreSQL`, `MongoDB` and `Cassandra` running.
 
 To run integration tests, run:
 ```sh

--- a/tests/test_paginator.py
+++ b/tests/test_paginator.py
@@ -43,6 +43,12 @@ def test_explicit_params():
     assert page == Page(items=[], total=0, page=2, pages=0, size=10)
 
 
+def test_custom_length_function():
+    page = paginate([1, 2, 3], Params(), length_function=lambda _: 10)
+
+    assert page == Page(items=[1, 2, 3], total=10, page=1, pages=1, size=50)
+
+
 def test_explicit_items_transformer():
     def transformer(items):
         return [item * 2 for item in items]


### PR DESCRIPTION
## Summary

Adds a focused test for the sync `paginate()` helper to verify that a custom `length_function` is used when calculating the page `total`.

## Motivation

The async paginator already has coverage for custom length functions. This adds similar coverage for the sync paginator without changing runtime behavior or public APIs.

## Tests

- `uv run pytest tests/test_paginator.py -q`
- `uv run pytest tests --ignore=tests/ext -q`