### PR TITLE
feat: support callable for `additional_data` parameter

### DIFF
--- a/fastapi_pagination/ext/beanie.py
+++ b/fastapi_pagination/ext/beanie.py
@@ -4,7 +4,7 @@ __all__ = ["apaginate", "paginate"]
 
 import inspect
 from copy import copy
-from typing import Any, Literal, TypeVar
+from typing import Any, Literal, TypeVar, cast
 
 from beanie import Document, PydanticObjectId
 from beanie.odm.enums import SortDirection
@@ -52,8 +52,9 @@ async def apaginate(  # noqa: C901, PLR0912, PLR0915
     **pymongo_kwargs: Any,
 ) -> Any:
     params, raw_params = verify_params(params, "limit-offset", "cursor")
-    if additional_data is None:
+    if not isinstance(additional_data, dict):
         additional_data = {}
+    additional_data = cast(dict[str, Any], additional_data)
 
     cursor = getattr(raw_params, "cursor", None)
     if isinstance(query, AggregationQuery):

--- a/fastapi_pagination/ext/bunnet.py
+++ b/fastapi_pagination/ext/bunnet.py
@@ -1,6 +1,6 @@
 __all__ = ["paginate"]
 
-from typing import Any, Literal, TypeVar
+from typing import Any, Literal, TypeVar, cast
 
 from bunnet import Document
 from bunnet.odm.enums import SortDirection
@@ -103,5 +103,5 @@ def paginate(
         t_items,
         total=total,
         params=params,
-        **(additional_data or {}),
+        **(cast(dict[str, Any], additional_data) if isinstance(additional_data, dict) else {}),
     )

--- a/fastapi_pagination/ext/cassandra.py
+++ b/fastapi_pagination/ext/cassandra.py
@@ -1,7 +1,7 @@
 __all__ = ["paginate"]
 
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import Any, TypeVar, cast
 
 from cassandra.cluster import SimpleStatement
 from cassandra.cqlengine import connection
@@ -45,5 +45,5 @@ def paginate(
         t_items,
         params=params,
         next_=cursor.paging_state,
-        **(additional_data or {}),
+        **(cast(dict[str, Any], additional_data) if isinstance(additional_data, dict) else {}),
     )

--- a/fastapi_pagination/ext/pymongo.py
+++ b/fastapi_pagination/ext/pymongo.py
@@ -9,7 +9,7 @@ __all__ = [
 
 
 from collections.abc import Mapping, Sequence
-from typing import Any, Literal, TypeVar
+from typing import Any, Literal, TypeVar, cast
 
 from pymongo.asynchronous.collection import AsyncCollection
 from pymongo.collection import Collection
@@ -153,7 +153,7 @@ def _aggregate_flow(
         params,
         total=total,
         transformer=transformer,
-        additional_data=additional_data,
+        additional_data=cast(dict[str, Any], additional_data) if isinstance(additional_data, dict) else None,
         config=config,
         async_=is_async,
     )

--- a/fastapi_pagination/ext/pymongo.py
+++ b/fastapi_pagination/ext/pymongo.py
@@ -20,7 +20,7 @@ from fastapi_pagination.ext.mongo import AggrPipelineTransformer
 from fastapi_pagination.ext.utils import get_mongo_pipeline_filter_end
 from fastapi_pagination.flow import flow, flow_expr, run_async_flow, run_sync_flow
 from fastapi_pagination.flows import create_page_flow, generic_flow
-from fastapi_pagination.types import AdditionalData, ItemsTransformer, SyncItemsTransformer
+from fastapi_pagination.types import AdditionalData, AdditionalDataCallable, ItemsTransformer, SyncItemsTransformer
 from fastapi_pagination.utils import verify_params
 
 T = TypeVar("T", bound=Mapping[str, Any])
@@ -148,12 +148,19 @@ def _aggregate_flow(
     except IndexError:
         total = 0
 
+    if isinstance(additional_data, dict):
+        resolved_additional_data: dict[str, Any] | None = cast(dict[str, Any], additional_data)
+    elif additional_data is not None:
+        resolved_additional_data = cast(AdditionalDataCallable, additional_data)(items)
+    else:
+        resolved_additional_data = None
+
     page = yield from create_page_flow(
         items,
         params,
         total=total,
         transformer=transformer,
-        additional_data=cast(dict[str, Any], additional_data) if isinstance(additional_data, dict) else None,
+        additional_data=resolved_additional_data,
         config=config,
         async_=is_async,
     )

--- a/fastapi_pagination/ext/sqlalchemy.py
+++ b/fastapi_pagination/ext/sqlalchemy.py
@@ -30,7 +30,13 @@ from fastapi_pagination.bases import AbstractParams, CursorRawParams, RawParams
 from fastapi_pagination.config import Config
 from fastapi_pagination.flow import flow, run_async_flow, run_sync_flow
 from fastapi_pagination.flows import CursorFlow, LimitOffsetFlow, TotalFlow, create_page_flow, generic_flow
-from fastapi_pagination.types import AdditionalData, AsyncItemsTransformer, ItemsTransformer, SyncItemsTransformer
+from fastapi_pagination.types import (
+    AdditionalData,
+    AdditionalDataCallable,
+    AsyncItemsTransformer,
+    ItemsTransformer,
+    SyncItemsTransformer,
+)
 from fastapi_pagination.utils import verify_params
 
 from .raw_sql import create_count_query_from_text as _create_count_query_from_text
@@ -381,12 +387,17 @@ def _sqlalchemy_inline_count_flow(
 
     items = _unwrap_items(result, query, unwrap_mode)
 
+    if not isinstance(additional_data, dict) and additional_data is not None:
+        resolved_additional_data: dict[str, Any] = cast(AdditionalDataCallable, additional_data)(result)
+    else:
+        resolved_additional_data = cast(dict[str, Any], additional_data or {})
+
     page = yield from create_page_flow(
         items,
         params_obj,
         total=total,
         transformer=transformer,
-        additional_data=additional_data or {},
+        additional_data=resolved_additional_data,
         config=config,
         async_=is_async,
         create_page_factory=create_page_factory,

--- a/fastapi_pagination/flows.py
+++ b/fastapi_pagination/flows.py
@@ -12,21 +12,21 @@ __all__ = [
 
 from collections.abc import Callable, Sequence
 from contextlib import ExitStack
-from typing import Any, Protocol, TypeAlias
+from typing import Any, Protocol, TypeAlias, cast
 
 from .api import apply_items_transformer, create_page, set_page
 from .bases import AbstractParams, CursorRawParams, RawParams, is_cursor, is_limit_offset
 from .config import Config
 from .flow import AnyFlow, flow
-from .types import AdditionalData, ItemsTransformer, ParamsType
+from .types import AdditionalData, AdditionalDataCallable, ItemsTransformer, ParamsType
 from .utils import verify_params
 
 LimitOffsetFlow: TypeAlias = AnyFlow
-CursorFlow: TypeAlias = AnyFlow[tuple[Any, AdditionalData | None]]
+CursorFlow: TypeAlias = AnyFlow[tuple[Any, dict[str, Any] | None]]
 TotalFlow: TypeAlias = AnyFlow[int | None]
 
 LimitOffsetFlowFunc: TypeAlias = Callable[[RawParams], AnyFlow]
-CursorFlowFunc: TypeAlias = Callable[[CursorRawParams], AnyFlow[tuple[Any, AdditionalData | None]]]
+CursorFlowFunc: TypeAlias = Callable[[CursorRawParams], AnyFlow[tuple[Any, dict[str, Any] | None]]]
 TotalFlowFunc: TypeAlias = Callable[[], AnyFlow[int | None]]
 
 
@@ -78,7 +78,7 @@ def create_page_flow(
 
 
 @flow
-def generic_flow(  # noqa: C901
+def generic_flow(  # noqa: C901, PLR0912
     *,
     limit_offset_flow: LimitOffsetFlowFunc | None = None,
     cursor_flow: CursorFlowFunc | None = None,
@@ -101,7 +101,6 @@ def generic_flow(  # noqa: C901
         raise ValueError("At least one flow must be provided")
 
     params, raw_params = verify_params(params, *types)
-    additional_data = additional_data or {}
 
     total = None
     if raw_params.include_total:
@@ -110,6 +109,7 @@ def generic_flow(  # noqa: C901
 
         total = yield from total_flow()
 
+    cursor_data: dict[str, Any] | None = None
     if is_limit_offset(raw_params):
         if limit_offset_flow is None:
             raise ValueError("limit_offset_flow is required for 'limit-offset' params")
@@ -119,8 +119,7 @@ def generic_flow(  # noqa: C901
         if cursor_flow is None:
             raise ValueError("cursor_flow is required for 'cursor' params")
 
-        items, more_data = yield from cursor_flow(raw_params)
-        additional_data.update(more_data or {})
+        items, cursor_data = yield from cursor_flow(raw_params)
     else:
         raise ValueError("Invalid params type")
 
@@ -131,12 +130,19 @@ def generic_flow(  # noqa: C901
             async_=async_,
         )
 
+    if not isinstance(additional_data, dict) and additional_data is not None:
+        resolved_data: dict[str, Any] = cast(AdditionalDataCallable, additional_data)(items)
+    else:
+        resolved_data = cast(dict[str, Any], additional_data or {})
+    if cursor_data:
+        resolved_data.update(cursor_data)
+
     page = yield from create_page_flow(
         items,
         params,
         total=total,
         transformer=transformer,
-        additional_data=additional_data,
+        additional_data=resolved_data,
         config=config,
         async_=async_,
         create_page_factory=create_page_factory,

--- a/fastapi_pagination/types.py
+++ b/fastapi_pagination/types.py
@@ -1,5 +1,6 @@
 __all__ = [
     "AdditionalData",
+    "AdditionalDataCallable",
     "AsyncItemsTransformer",
     "Cursor",
     "GreaterEqualOne",
@@ -15,7 +16,8 @@ from pydantic import conint
 
 Cursor: TypeAlias = str | bytes
 ParamsType: TypeAlias = Literal["cursor", "limit-offset"]
-AdditionalData: TypeAlias = dict[str, Any]
+AdditionalDataCallable: TypeAlias = Callable[[Sequence[Any]], dict[str, Any]]
+AdditionalData: TypeAlias = dict[str, Any] | AdditionalDataCallable
 
 AsyncItemsTransformer: TypeAlias = Callable[[Sequence[Any]], Sequence[Any] | Awaitable[Sequence[Any]]]
 SyncItemsTransformer: TypeAlias = Callable[[Sequence[Any]], Sequence[Any]]

--- a/tests/ext/test_sqlalchemy.py
+++ b/tests/ext/test_sqlalchemy.py
@@ -479,7 +479,7 @@ class TestSQLAlchemyInlineCount:
         assert page.fallback == "empty"
         assert page.total == 0
 
-    def test_inline_additional_data_callable_requires_inline_count(self, sa_session, sa_user, entities):
+    def test_callable_additional_data_without_inline_count(self, sa_session, sa_user, entities):
         """Callable additional_data works without inline_count, receiving unwrapped items."""
         CustomPage = CustomizedPage[Page[Any], UseAdditionalFields(page_item_count=(int, ...))]
 

--- a/tests/ext/test_sqlalchemy.py
+++ b/tests/ext/test_sqlalchemy.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import selectinload
 
 from fastapi_pagination import Page, Params, set_page, set_params
 from fastapi_pagination.cursor import CursorPage
-from fastapi_pagination.customization import CustomizedPage, UseQuotedCursor
+from fastapi_pagination.customization import CustomizedPage, UseAdditionalFields, UseQuotedCursor
 from fastapi_pagination.ext.sqlalchemy import apaginate, paginate
 from tests.base import BasePaginationTestSuite, SuiteBuilder, async_sync_testsuite, sync_testsuite
 from tests.ext.utils import is_sqlalchemy20
@@ -432,3 +432,63 @@ class TestSQLAlchemyInlineCount:
             legacy_query = session.query(sa_user)
             with pytest.raises(TypeError, match="inline_count is not supported"):
                 paginate(session, legacy_query, inline_count=func.count().over())
+
+    def test_inline_additional_data_callable_basic(self, sa_session, sa_user, entities):
+        """Callable additional_data extracts aggregated values from raw rows."""
+
+        CustomPage = CustomizedPage[Page[Any], UseAdditionalFields(user_count_sum=(int, ...))]
+
+        stmt = select(
+            sa_user,
+            func.count(sa_user.id).over().label("_inline_total"),
+        ).order_by(sa_user.id)
+
+        def extract(rows):
+            return {"user_count_sum": rows[0]._mapping["_inline_total"] if rows else 0}
+
+        with closing(sa_session()) as session, set_page(CustomPage):
+            page = paginate(
+                session,
+                stmt,
+                params=Params(page=1, size=10),
+                inline_count=func.count().over(),
+                additional_data=extract,
+            )
+
+        assert page.user_count_sum == page.total
+
+    def test_inline_additional_data_callable_empty_page(self, sa_session, sa_user):
+        """Callable receives an empty list when query returns no rows."""
+
+        CustomPage = CustomizedPage[Page[Any], UseAdditionalFields(fallback=(str, ...))]
+
+        stmt = select(sa_user).where(sa_user.id == -999)
+
+        def extract(rows):
+            return {"fallback": "empty" if not rows else "found"}
+
+        with closing(sa_session()) as session, set_page(CustomPage):
+            page = paginate(
+                session,
+                stmt,
+                params=Params(page=1, size=10),
+                inline_count=func.count().over(),
+                additional_data=extract,
+            )
+
+        assert page.fallback == "empty"
+        assert page.total == 0
+
+    def test_inline_additional_data_callable_requires_inline_count(self, sa_session, sa_user, entities):
+        """Callable additional_data works without inline_count, receiving unwrapped items."""
+        CustomPage = CustomizedPage[Page[Any], UseAdditionalFields(page_item_count=(int, ...))]
+
+        with closing(sa_session()) as session, set_page(CustomPage):
+            page = paginate(
+                session,
+                select(sa_user),
+                params=Params(page=1, size=10),
+                additional_data=lambda items: {"page_item_count": len(items)},
+            )
+
+        assert page.page_item_count == len(page.items)


### PR DESCRIPTION
### What problem was solved?

Previously, `additional_data` only accepted a plain `dict[str, Any]`, which forced users to run a separate aggregate query to compute derived values (e.g., totals, balances) and manually pass them to `paginate()`. This was redundant since the paginated query already fetches the rows.

This PR adds support for passing a callable to `additional_data`. The callable receives the fetched rows (or ORM instances, depending on the path) and returns a `dict[str, Any]`. This way, aggregated values can be derived directly from the result set of the pagination query — no extra query needed.

Two execution paths are supported:
- **`inline_count` path (SQLAlchemy)** — callable receives raw `Row` objects, including any window function columns (e.g., `func.sum().over()`)
- **Generic flow path** — callable receives the items after the `inner_transformer` is applied

The change is fully backward-compatible: `additional_data` still accepts a plain dict as before.

### How to test?

Pass a callable to `additional_data` in `paginate()`:

```python
def compute_totals(rows):
    return {"total": sum(r.amount for r in rows)}

paginate(db, query, additional_data=compute_totals)
```

### Other information

- The new type alias `AdditionalDataCallable` is exported from `fastapi_pagination.types`
- All extension modules (beanie, bunnet, cassandra, pymongo) correctly ignore the callable and treat it as no additional data, since those extensions do not support row-level access in the same way
- `cast()` calls were added in affected files to satisfy the `ty` type checker, which does not narrow `isinstance(x, dict)` to `dict[str, Any]`