### PR TITLE
docs: use apaginate in async paginator examples

### DIFF
--- a/docs/learn/tutorial_user_guide/items_transformer.md
+++ b/docs/learn/tutorial_user_guide/items_transformer.md
@@ -67,12 +67,12 @@ async def another_route() -> Page[int]:
     return paginate(range(100))
 ```
 
-If `paginate` function is async, then the transformer can be async too:
+If the pagination function is async, then the transformer can be async too:
 
 ```py
 from fastapi import FastAPI
 from fastapi_pagination import Page, add_pagination
-from fastapi_pagination.async_paginator import paginate
+from fastapi_pagination.async_paginator import apaginate
 
 app = FastAPI()
 add_pagination(app)
@@ -83,5 +83,5 @@ async def transformer(items: list[int]) -> list[int]:
 # req: GET /ints?page=2&size=5
 @app.get("/ints")
 async def route() -> Page[int]:
-    return await paginate(range(100), transformer=transformer)
+    return await apaginate(range(100), transformer=transformer)
 ```

--- a/docs/learn/tutorial_user_guide/paginate.md
+++ b/docs/learn/tutorial_user_guide/paginate.md
@@ -54,15 +54,15 @@ For sync `paginate`, `additional_data` can be either:
 
 For `fastapi_pagination.async_paginator.apaginate`, `additional_data` can also be an async callable.
 
-## Async `paginate` function
+## Async `apaginate` function
 
-If you want to use async `paginate` function, you can use `fastapi_pagination.async_paginator` module.
+If you want to use async pagination, you can use `apaginate` from the `fastapi_pagination.async_paginator` module.
 It exists to be able to use async `transformer` function.
 
 ```py
 from fastapi import FastAPI
 from fastapi_pagination import add_pagination, Page
-from fastapi_pagination.async_paginator import paginate
+from fastapi_pagination.async_paginator import apaginate
 
 app = FastAPI()
 add_pagination(app)
@@ -70,10 +70,10 @@ add_pagination(app)
 # req: GET /nums?page=2&size=10
 @app.get("/nums")
 async def get_users() -> Page[int]:
-    return await paginate(range(200))
+    return await apaginate(range(200))
 ```
 
-Async `paginate` also supports async `additional_data` callbacks:
+Async `apaginate` also supports async `additional_data` callbacks:
 
 ```py
 from fastapi_pagination.async_paginator import apaginate


### PR DESCRIPTION
## Summary

- Update async paginator documentation examples to import and call `apaginate`
- Adjust nearby wording to avoid referring to the deprecated async `paginate` helper

## Motivation

The async `paginate` helper in `fastapi_pagination.async_paginator` is deprecated in favor of `apaginate`.
These docs examples now match the current recommended API.

## Verification

- `git diff --check`
- Searched docs for remaining deprecated async paginator import/call patterns